### PR TITLE
Add ngrok to config.hosts in development env config

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,4 +59,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.hosts << /[a-z0-9]+\.ngrok\.io/
 end


### PR DESCRIPTION
Rails throws an error screen if you don't have this with ngrok.