### PR TITLE
Save stripe_charge_id in Postcards & detect failed payment

### DIFF
--- a/app/jobs/send_postcard_job.rb
+++ b/app/jobs/send_postcard_job.rb
@@ -3,9 +3,11 @@ class SendPostcardJob < ApplicationJob
 
   attr_accessor :postcard
 
-  def perform(postcard_id)
-    @postcard = Postcard.find_by_id(postcard_id)
+  def perform(postcard)
+    @postcard = postcard
     return if postcard.nil?
+
+    return unless stripe_charge_successful?
 
     lob.postcards.create(
       description: postcard.lob_description,
@@ -21,6 +23,11 @@ class SendPostcardJob < ApplicationJob
       photo_url: postcard.photo.ig_permalink,
       caption: postcard.caption
     }
+  end
+
+  def stripe_charge_successful?
+    charge = Stripe::Charge.retrive(postcard.stripe_charge_id)
+    return charge['paid']
   end
 
   def lob

--- a/app/models/postcard.rb
+++ b/app/models/postcard.rb
@@ -1,6 +1,7 @@
 class Postcard < ApplicationRecord
   belongs_to :photo
   belongs_to :recipient, optional: true
+  after_commit :send_with_lob_if_sendable
 
   enum status: %i[in_transit in_local_area processed_for_delivery re_routed
                   returned_to_sender]
@@ -9,5 +10,17 @@ class Postcard < ApplicationRecord
 
   def lob_description
     "postcard_id_#{id}"
+  end
+
+  private
+
+  def send_with_lob_if_sendable
+    SendPostcardJob.perform_async(self) if sendable?
+  end
+
+  def sendable?
+    !recipient.nil? &&
+      !photo.nil? &&
+      !stripe_charge_id.nil?
   end
 end

--- a/db/migrate/20191114031533_add_stripe_charge_id_to_postcards.rb
+++ b/db/migrate/20191114031533_add_stripe_charge_id_to_postcards.rb
@@ -1,0 +1,5 @@
+class AddStripeChargeIdToPostcards < ActiveRecord::Migration[6.0]
+  def change
+    add_column :postcards, :stripe_charge_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_10_232302) do
+ActiveRecord::Schema.define(version: 2019_11_14_031533) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(version: 2019_11_10_232302) do
     t.text "caption"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "stripe_charge_id"
     t.index ["photo_id"], name: "index_postcards_on_photo_id"
     t.index ["recipient_id"], name: "index_postcards_on_recipient_id"
   end


### PR DESCRIPTION
fixes #9 

* Updates `postcard.stripe_charge_id` after a payment is created.
* Updates `flash` message after an unsuccessful payment.