### PR TITLE
Cascade deletes on User & Photo

### DIFF
--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -2,7 +2,7 @@
 
 # A photo that could be featured on a Postcard
 class Photo < ApplicationRecord
-  has_many :postcards
+  has_many :postcards, dependent: :destroy
   belongs_to :user
   validates_uniqueness_of :ig_id
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,8 +2,8 @@
 
 # User Model
 class User < ApplicationRecord
-  has_many :photos
-  has_many :recipients
+  has_many :photos, dependent: :destroy
+  has_many :recipients, dependent: :destroy
   has_many :postcards, through: :photos
 
   after_commit :save_customer


### PR DESCRIPTION
When a User is destroyed, we want to destroy their associated models. @edance let me know if you have issues with this.